### PR TITLE
[feature] support saving coverage data

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,15 @@ There are some limitations:
 2. Coverage plugin is not tested. It may not work well.
 3. `pytest-xdist` is not tested. It may not work well.
 4. To set context of subprocess correctly, you need to set test batch size to 1, which may slow down the test.
+
+## Coverage report
+
+We support saving coverage data in `.coverage` file. To enable it:
+
+```shell
+pytest --testmon --testmon-cov $SOURCE tests
+```
+
+Known issues:
+1. This is not compatible with `pytest-cov`. You'd better uninstall `pytest-cov` before using this feature.
+2. If you don't specify `$SOURCE` (`pytest --testmon --testmon-cov tests`), we will use record everything. This behavior is different from `coverage.py`. Thus, we highly recommend you to specify `$SOURCE`.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2,7 +2,6 @@
 set -xe
 
 TEST_ROOT=$(realpath $(dirname $0))
-export PYTHONPATH=${PYTHONPATH}:${TEST_ROOT}
 
 # install requirements
 pip install -r ${TEST_ROOT}/requirements.txt
@@ -44,3 +43,21 @@ pytest --testmon ${TEST_ROOT} | grep "collected 0 items"
 
 # restore sample.py
 mv ${TEST_ROOT}/.sample.py.bak ${TEST_ROOT}/sample.py
+
+# test coverage report
+if [ -e ${TEST_ROOT}/../.coverage ]; then
+    rm ${TEST_ROOT}/../.coverage
+fi
+
+coverage run --source ${TEST_ROOT} -m pytest ${TEST_ROOT}
+coverage combine
+coverage report -m > ${TEST_ROOT}/coverage.txt
+rm ${TEST_ROOT}/../.coverage
+
+rm ${TEST_ROOT}/../.testmondata
+pytest --testmon --testmon-cov ${TEST_ROOT} ${TEST_ROOT}
+coverage report -m > ${TEST_ROOT}/coverage_with_testmon.txt
+rm ${TEST_ROOT}/../.coverage
+
+diff ${TEST_ROOT}/coverage.txt ${TEST_ROOT}/coverage_with_testmon.txt
+rm ${TEST_ROOT}/coverage.txt ${TEST_ROOT}/coverage_with_testmon.txt


### PR DESCRIPTION
We support saving coverage data in `.coverage` file. To enable it:

```shell
pytest --testmon --testmon-cov $SOURCE tests
```

Known issues:
1. This is not compatible with `pytest-cov`. You'd better uninstall `pytest-cov` before using this feature.
2. If you don't specify `$SOURCE` (`pytest --testmon --testmon-cov tests`), we will use record everything. This behavior is different from `coverage.py`. Thus, we highly recommend you to specify `$SOURCE`.